### PR TITLE
Add --profile option for multiple Chrome profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If your chromium based browser has a different name use the `--exe` flag with an
 
 ## **Usage**
 
-#### `bing-rewards [-h] [--no-window] [-n] [--exe EXE] [-c COUNT] [-d | -m]`
+#### `bing-rewards [-h] [--no-window] [-n] [--exe EXE] [-c COUNT] [-d | -m] [--profile "Profile X"]`
 
 Ex:
 Complete mobile and desktop daily points
@@ -70,6 +70,10 @@ Run 10 searches with mobile user-agent in a new window
 
 `$ bing-rewards --mobile --count=10`
 
+Complete mobile and desktop daily points using specified chrome profile "Profile 1"
+
+`$ bing-rewards --profile "Profile 1"`
+
 Launches Chrome as a subprocess with special flags. Tested on Windows 10 and Linux (Ubuntu + Arch), however it should work on Mac OS as well.
 
 ⚠️Known Issue: No other instance of chrome.exe can be open when the script runs. Chrome prevents different user agents in each window. The script will run, but Chrome will not appear as Edge
@@ -80,19 +84,20 @@ Launches Chrome as a subprocess with special flags. Tested on Windows 10 and Lin
 Running with no options will complete mobile and desktop daily search quota.
 The following options are available to change the default behavior.
 Options supplied at execution time override any config.
-| Flag                    | Option                                                                              |
-| ----------------------- | ----------------------------------------------------------------------------------- |
-| `-h`, `--help`          | Display help and exit                                                               |
-| `-c`, `--count=N`       | Override the number of searches to complete                                         |
-| `-d`, `--desktop`       | Only use desktop user agent                                                         |
-| `-m`, `--mobile`        | Only use a mobile user agent                                                        |
-| `-n`, `--dryrun`        | Do everything but type the search query                                             |
-| `--open-rewards`   | Open the rewards page at the end of the run                                         |
-| `-X`, `--no-exit`       | Do not close the browser after completing a search                                  |
-| `--load-delay`     | Override the time given to Chrome to load in seconds                                |
-| `--search-delay`   | Override the time between searches in seconds                                       |
-| `--exe EXE`             | The full path of the Chrome compatible browser executable (Brave and Chrome tested) |
-| `--nowindow`            | Don't open a new Chrome window, just type the keys                                  |
+| Flag                    | Option                                                                                |
+| ----------------------- | --------------------------------------------------------------------------------------|
+| `-h`, `--help`          | Display help and exit                                                                 |
+| `-c`, `--count=N`       | Override the number of searches to complete                                           |
+| `-d`, `--desktop`       | Only use desktop user agent                                                           |
+| `-m`, `--mobile`        | Only use a mobile user agent                                                          |
+| `-n`, `--dryrun`        | Do everything but type the search query                                               |
+| `--open-rewards`        | Open the rewards page at the end of the run                                           |
+| `-X`, `--no-exit`       | Do not close the browser after completing a search                                    |
+| `--load-delay`          | Override the time given to Chrome to load in seconds                                  |
+| `--search-delay`        | Override the time between searches in seconds                                         |
+| `--exe EXE`             | The full path of the Chrome compatible browser executable (Brave and Chrome tested)   |
+| `--nowindow`            | Don't open a new Chrome window, just type the keys                                    |
+| `--profile "Profile N"` | Launches chrome using the specified profile.                                          |
 
 A config file is also generated in $XDG_CONFIG_HOME or %APPDATA% on Windows
 where precise delay modifications can be made.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Options supplied at execution time override any config.
 | `--search-delay`        | Override the time between searches in seconds                                         |
 | `--exe EXE`             | The full path of the Chrome compatible browser executable (Brave and Chrome tested)   |
 | `--nowindow`            | Don't open a new Chrome window, just type the keys                                    |
-| `--profile "Profile N"` | Launches chrome using the specified profile.                                          |
+| `--profile "Profile N"` | Launches chrome using the specified profile. Otherwise use default.                   |
 
 A config file is also generated in $XDG_CONFIG_HOME or %APPDATA% on Windows
 where precise delay modifications can be made.


### PR DESCRIPTION
Love your script. I needed an option to automate the rewards for multiple chrome users, this change adds the option to set a chrome profile - eg. bing-rewards --profile "Profile 1" will launch chrome with --profile-directory=Profile 1. 

The idea is that you can set tasks to conduct bing-rewards for multiple users in chrome.