### PR TITLE
Add --bing flag; increase default searches count and search delay

### DIFF
--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -117,6 +117,12 @@ def parse_args():
         help="The full path of the Chrome compatible browser executable",
         type=check_path,
     )
+    p.add_argument(
+        "-b",
+        "--bing",
+        help="Add this flag if your default search engine is Bing",
+        action="store_true"
+    )
     # Mutually exclusive options. Only one can be present
     group = p.add_mutually_exclusive_group()
     group.add_argument(
@@ -303,8 +309,13 @@ def search(count, words_gen: Generator, agent, args, config):
         # Get a random query from set of words
         query = next(words_gen)
 
-        # Concatenate url with correct url escape characters
-        search_url = (config.get("search-url") or URL) + quote_plus(query)
+        # If the --bing flag is set, type the query to the address bar directly
+        if args.bing: 
+            search_url = query
+        else: 
+            # Concatenate url with correct url escape characters
+            search_url = (config.get("search-url") or URL) + quote_plus(query)
+
         # Use pynput to trigger keyboard events and type search querys
         if not args.dryrun:
             # Alt + D to focus the address bar in most browsers

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -53,13 +53,14 @@ DESKTOP_AGENT = (
 
 
 # Number of searches to make
-DESKTOP_COUNT = 30
-MOBILE_COUNT = 20
+DESKTOP_COUNT = 33
+MOBILE_COUNT = 23
 
 # Time to allow Chrome to load in seconds
 LOAD_DELAY = 1.5
 # Time between searches in seconds
-SEARCH_DELAY = 2
+# Searches does not count if they are done earlier than ~6 seconds
+SEARCH_DELAY = 6
 
 # Bing Search base url, with new form= parameter (code differs per browser?)
 URL = "https://www.bing.com/search?form=QBRE&q="


### PR DESCRIPTION
Love your script!

I simply added a `--bing` flag to tell the script that you have set Bing as your default search engine. This just ignores the addition of url stuffs in the address bar, and ingeniously bypasses the new `FORM=` argument in Bing search URLs. 

Also, added additional 3 searches to Desktop and Mobile, since Bing changed their terms:
["Earning starts with your third search."](https://www.reddit.com/r/MicrosoftRewards/comments/187nalv/earning_starts_with_your_third_search/)
People also commented out that their points are not adding up when searching without a delay of more than 5 seconds, so I just bumped up the default search delay to 6 seconds.

Some minor additions/fixes to Bing's recent changes.