### PR TITLE
`--bing` flag minor change

### DIFF
--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -310,6 +310,14 @@ def search(count, words_gen: Generator, agent, args, config):
         # Get a random query from set of words
         query = next(words_gen)
 
+        # Determine the key combination to use based on the --bing flag
+        if args.bing:
+            # Ctrl + E to open address bar wit the default search engine
+            key_combo = (Key.ctrl, "e")
+        else:
+            # Alt + D focuses address bar without using search engine
+            key_combo = (Key.alt, "d")
+
         # If the --bing flag is set, type the query to the address bar directly
         if args.bing:
             search_url = query
@@ -317,13 +325,12 @@ def search(count, words_gen: Generator, agent, args, config):
             # Concatenate url with correct url escape characters
             search_url = (config.get("search-url") or URL) + quote_plus(query)
 
-        # Use pynput to trigger keyboard events and type search querys
+        # Use pynput to trigger keyboard events and type search queries
         if not args.dryrun:
-            # Alt + D to focus the address bar in most browsers
-            key_controller.press(Key.alt)
-            key_controller.press("d")
-            key_controller.release("d")
-            key_controller.release(Key.alt)
+            key_controller.press(key_combo[0])
+            key_controller.press(key_combo[1])
+            key_controller.release(key_combo[1])
+            key_controller.release(key_combo[0])
 
             if args.ime:
                 # Incase users use a Windows IME, change the language to English

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -306,20 +306,16 @@ def search(count, words_gen: Generator, agent, args, config):
     # keyboard controller from pynput
     key_controller = keyboard.Controller()
 
+    # Ctrl + E to open address bar with the default search engine
+    # Alt + D focuses address bar without using search engine
+    key_combo = (Key.ctrl, "e") if args.bing else (Key.ctrl, "e")    
+
     for i in range(count):
         # Get a random query from set of words
         query = next(words_gen)
 
-        # Determine the key combination to use based on the --bing flag
         if args.bing:
-            # Ctrl + E to open address bar wit the default search engine
-            key_combo = (Key.ctrl, "e")
-        else:
-            # Alt + D focuses address bar without using search engine
-            key_combo = (Key.alt, "d")
-
-        # If the --bing flag is set, type the query to the address bar directly
-        if args.bing:
+            # If the --bing flag is set, type the query to the address bar directly
             search_url = query
         else:
             # Concatenate url with correct url escape characters
@@ -327,10 +323,9 @@ def search(count, words_gen: Generator, agent, args, config):
 
         # Use pynput to trigger keyboard events and type search queries
         if not args.dryrun:
-            key_controller.press(key_combo[0])
-            key_controller.press(key_combo[1])
-            key_controller.release(key_combo[1])
-            key_controller.release(key_combo[0])
+            with key_controller.pressed(key_combo[0]):
+                key_controller.press(key_combo[1])
+                key_controller.release(key_combo[1])
 
             if args.ime:
                 # Incase users use a Windows IME, change the language to English

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -308,7 +308,7 @@ def search(count, words_gen: Generator, agent, args, config):
 
     # Ctrl + E to open address bar with the default search engine
     # Alt + D focuses address bar without using search engine
-    key_combo = (Key.ctrl, "e") if args.bing else (Key.ctrl, "e")    
+    key_combo = (Key.ctrl, "e") if args.bing else (Key.alt, "d")    
 
     for i in range(count):
         # Get a random query from set of words


### PR DESCRIPTION
Use `ctrl + e` instead of `alt + d` if the `--bing` flag is present, this ensures that every search attempt uses the default search engine set in the browser. 

Function of each:
`Ctrl + e`: Opens the address bar and uses the default search engine for the query
`Alt + d`: Opens the address bar (can enter links)

Just a minor change to fix a minor problem. There can be times wherein a search term could be a name of a website. For example, when the query is `youtube`, the address bar would auto-append `.com` to it and just open YouTube; when using `Ctrl + e`, it uses the default search engine, which is Bing in this case, to search for `youtube` and not go to `youtube.com`