### PR TITLE
add `package` argument for `resources.files()`

### DIFF
--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -50,7 +50,7 @@ def word_generator() -> Generator[str]:
     Starts reading from a random position in the file.
     If end of file is reached, close and restart.
     """
-    word_data = resources.files().joinpath('data', 'keywords.txt')
+    word_data = resources.files('bing_rewards').joinpath('data', 'keywords.txt')
     while True:
         with (
             resources.as_file(word_data) as p,


### PR DESCRIPTION
running `bing-rewards` in the terminal opens a browser window, however, exits prematurely since there happens to be something missing in the code itself.

note: bing-rewards installed using `pipx`.

```shell
$ bing-rewards
Doing 33 desktop searches
Press ESC to quit searching
Opening browser [1508]
Exception in thread Thread-1 (both):
Traceback (most recent call last):
  File "C:\Users\meina\AppData\Local\Programs\Python\Python311\Lib\threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "C:\Users\meina\AppData\Local\Programs\Python\Python311\Lib\threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\meina\AppData\Local\pipx\pipx\venvs\bing-rewards\Lib\site-packages\bing_rewards\__init__.py", line 213, in both
    desktop()
  File "C:\Users\meina\AppData\Local\pipx\pipx\venvs\bing-rewards\Lib\site-packages\bing_rewards\__init__.py", line 201, in desktop
    search(count, words_gen, options.desktop_agent, options)
  File "C:\Users\meina\AppData\Local\pipx\pipx\venvs\bing-rewards\Lib\site-packages\bing_rewards\__init__.py", line 149, in search
    query = next(words_gen)
            ^^^^^^^^^^^^^^^
  File "C:\Users\meina\AppData\Local\pipx\pipx\venvs\bing-rewards\Lib\site-packages\bing_rewards\__init__.py", line 53, in word_generator
    word_data = resources.files().joinpath('data', 'keywords.txt')
                ^^^^^^^^^^^^^^^^^
TypeError: files() missing 1 required positional argument: 'package'
```