### PR TITLE
hotfix: `package` argument for `resources.files()` (#49)

### DIFF
--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -50,7 +50,7 @@ def word_generator() -> Generator[str]:
     Starts reading from a random position in the file.
     If end of file is reached, close and restart.
     """
-    word_data = resources.files().joinpath('data', 'keywords.txt')
+    word_data = resources.files('bing_rewards').joinpath('data', 'keywords.txt')
     while True:
         with (
             resources.as_file(word_data) as p,


### PR DESCRIPTION

resources.files requires a positional argument in python versions before 3.12