### PR TITLE
Some README and docstring changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Options supplied at execution time override any config.
 | `-d`, `--desktop`       | Only use desktop user agent                                                           |
 | `-m`, `--mobile`        | Only use a mobile user agent                                                          |
 | `-n`, `--dryrun`        | Do everything but type the search query                                               |
-| `--bing`                | Use this flag if Bing is already your default search engine. Bypasses constructing a bing.com URL |
+| `-b`, `--bing`          | Use this flag if Bing is already your default search engine. Bypasses constructing a bing.com URL |
 | `--open-rewards`        | Open the rewards page at the end of the run                                           |
 | `-X`, `--no-exit`       | Do not close the browser after completing a search                                    |
 | `--load-delay`          | Override the time given to Chrome to load in seconds                                  |

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Mobile Edge Browser on Pixel 6 phone:
 
 
 ## Words:
-The [keywords](https://www.myhelpfulguides.com/keywords.txt) included in this repo where taken from this site
-https://www.myhelpfulguides.com/2018/07/19/bing-rewards-auto-searcher-with-python-3/.
+The [keywords](https://web.archive.org/web/20220523083250/https://www.myhelpfulguides.com/keywords.txt) included in this repo where taken from this site
+[https://www.myhelpfulguides.com/2018/07/19/bing-rewards-auto-searcher-with-python-3/](https://web.archive.org/web/20220331033847/https://www.myhelpfulguides.com/2018/07/19/bing-rewards-auto-searcher-with-python-3/).
 
 This script provided the original inspiration but has since been complelty rewritten and expanded.
 The original author was contacted for the original source of keywords, but declined to respond

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -6,8 +6,8 @@ followed by {MOBILE_COUNT} mobile searches by default.
 
 Examples
 --------
-    $ bing-search -nmc30
-    $ bing-search --new --count=50 --mobile --dryrun
+    $ bing-search -dc30
+    $ bing-search --count=50 --mobile --dryrun
 
 Config file: {CONFIG}
 CLI arguments always override the config file.


### PR DESCRIPTION
Some little changes for documentation.

Changes in README:
- Added `-b` in flags as shorthand for `-bing`
- Used archive.org's copy of the website for the [keywords](https://www.myhelpfulguides.com/keywords.txt) and [the script where it came from](https://www.myhelpfulguides.com/2018/07/19/bing-rewards-auto-searcher-with-python-3/), since both are unreachable (at least on my end). 

Changes in `__init__.py`:
- Removed the `-n` and/or `--new` flag in the example in the docstring, since they do not exist in the module anymore.