### PR TITLE
`word_generator()` changes

### DIFF
--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -55,17 +55,17 @@ def word_generator() -> Generator[str, None, None]:
         str: A random keyword from the file, stripped of whitespace.
 
     Raises:
-        FileNotFoundError: If the keywords file cannot be found.
-        IOError: If there are issues reading the file.
+        OSError: If there are issues accessing or reading the file.
     """
     word_data = resources.files('bing_rewards').joinpath('data', 'keywords.txt')
-    while True:
-        try:
+
+    try:
+        while True:
             with (
                 resources.as_file(word_data) as p,
                 p.open(mode='r', encoding='utf-8') as fh,
             ):
-                # Get the filesize of the Keywords file
+                # Get the file size of the Keywords file
                 fh.seek(0, SEEK_END)
                 size = fh.tell()
 
@@ -79,23 +79,23 @@ def word_generator() -> Generator[str, None, None]:
                 fh.readline()
 
                 # Read lines until EOF
-                for line in fh:
-                    line = line.strip()
-                    if line:  # Skip empty lines
-                        yield line
+                for raw_line in fh:
+                    stripped_line = raw_line.strip()
+                    if stripped_line:  # Skip empty lines
+                        yield stripped_line
 
                 # If we hit EOF, seek back to start and continue until we've yielded enough words
                 fh.seek(0)
-                for line in fh:
-                    line = line.strip()
-                    if line:
-                        yield line
-        except (FileNotFoundError, IOError) as e:
-            print(f"Error accessing keywords file: {e}")
-            raise
-        except Exception as e:
-            print(f"Unexpected error in word generation: {e}")
-            raise
+                for raw_line in fh:
+                    stripped_line = raw_line.strip()
+                    if stripped_line:
+                        yield stripped_line
+    except OSError as e:
+        print(f"Error accessing keywords file: {e}")
+        raise
+    except Exception as e:
+        print(f"Unexpected error in word generation: {e}")
+        raise
 
 
 def browser_cmd(exe: Path, agent: str, profile: str = '') -> list[str]:

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -44,11 +44,19 @@ from pynput.keyboard import Key
 import bing_rewards.options as app_options
 
 
-def word_generator() -> Generator[str]:
+def word_generator() -> Generator[str, None, None]:
     """Infinitely generate terms from the word file.
 
     Starts reading from a random position in the file.
     If end of file is reached, close and restart.
+    Handles file operations safely and ensures uniform random distribution.
+
+    Yields:
+        str: A random keyword from the file, stripped of whitespace.
+
+    Raises:
+        FileNotFoundError: If the keywords file cannot be found.
+        IOError: If there are issues reading the file.
     """
     word_data = resources.files('bing_rewards').joinpath('data', 'keywords.txt')
     while True:

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -70,7 +70,7 @@ def word_generator() -> Generator[str, None, None]:
                 size = fh.tell()
 
                 if size == 0:
-                    raise ValueError("Keywords file is empty")
+                    raise ValueError('Keywords file is empty')
 
                 # Start at a random position in the stream
                 fh.seek(random.randint(0, size - 1), SEEK_SET)
@@ -91,10 +91,10 @@ def word_generator() -> Generator[str, None, None]:
                     if stripped_line:
                         yield stripped_line
     except OSError as e:
-        print(f"Error accessing keywords file: {e}")
+        print(f'Error accessing keywords file: {e}')
         raise
     except Exception as e:
-        print(f"Unexpected error in word generation: {e}")
+        print(f'Unexpected error in word generation: {e}')
         raise
 
 


### PR DESCRIPTION
This pull request includes several improvements to the `word_generator` function in the `bing_rewards/__init__.py` file. The changes enhance error handling, ensure uniform random distribution, and improve code readability.

Enhancements to `word_generator` function:

* Type hints: specified the return type as `Generator[str, None, None]`.
* Added yields and potential exceptions in the docstring.
* Implemented error handling for `FileNotFoundError` and `IOError`, with appropriate error messages and re-raising of exceptions.
* Ensured the function handles empty keyword files by raising a `ValueError` if the file size is zero. (Useful when implementing a feature to add your own .txt files for searches)
* Improved the random starting position logic (to capture the whole txt file) and ensured clean line boundaries by discarding partial lines and skipping empty lines.