### PR TITLE
Add support for running multiple Chrome profiles sequentially

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Complete mobile and desktop daily points using specified chrome profile "Profile
 
 `$ bing-rewards --profile "Profile 1"`
 
+Run searches sequentially across multiple Chrome profiles
+
+`$ bing-rewards --profile "Default" "Profile 1" "Profile 2"`
+
 Launches Chrome as a subprocess with special flags. Tested on Windows 10 and Linux (Ubuntu + Arch), however it should work on Mac OS as well.
 
 ⚠️Known Issue: No other instance of chrome.exe can be open when the script runs. Chrome prevents different user agents in each window. The script will run, but Chrome will not appear as Edge
@@ -91,7 +95,7 @@ Options supplied at execution time override any config.
 | `--search-delay`        | Override the time between searches in seconds                                         |
 | `--exe EXE`             | The full path of the Chrome compatible browser executable (Brave and Chrome tested)   |
 | `--nowindow`            | Don't open a new Chrome window, just type the keys                                    |
-| `--profile "Profile N"` | Launches chrome using the specified profile. Otherwise use default.                   |
+| `--profile`             | Run searches using specified Chrome profile(s). Multiple profiles can be specified to run sequentially |
 | `--ime`                 | Triggers Windows IME to switch to English input by pressing "shift"                   |
 
 A config file is also generated in $XDG_CONFIG_HOME or %APPDATA% on Windows

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -195,8 +195,7 @@ def main():
     def desktop(profile=''):
         # Complete search with desktop settings
         count = options.count if 'count' in options else options.desktop_count
-        profile_msg = f" using profile '{profile}'" if profile else ''
-        print(f'Doing {count} desktop searches{profile_msg}')
+        print(f'Doing {count} desktop searches using "{profile}"')
 
         temp_options = options
         temp_options.profile = profile
@@ -206,8 +205,7 @@ def main():
     def mobile(profile=''):
         # Complete search with mobile settings
         count = options.count if 'count' in options else options.mobile_count
-        profile_msg = f" using profile '{profile}'" if profile else ''
-        print(f'Doing {count} mobile searches{profile_msg}')
+        print(f'Doing {count} mobile searches using "{profile}"')
 
         temp_options = options
         temp_options.profile = profile

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -232,7 +232,7 @@ def main():
 
     for profile in profiles:
         # Start the searching in separate thread
-        search_thread = threading.Thread(target=lambda: target_func(profile), daemon=True)
+        search_thread = threading.Thread(target=lambda p=profile: target_func(p), daemon=True)
         search_thread.start()
 
         print('Press ESC to quit searching')

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -206,7 +206,7 @@ def main():
     def mobile(profile=''):
         # Complete search with mobile settings
         count = options.count if 'count' in options else options.mobile_count
-        profile_msg = f" using profile '{profile}'" if profile else ""
+        profile_msg = f" using profile '{profile}'" if profile else ''
         print(f'Doing {count} mobile searches{profile_msg}')
 
         temp_options = options

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -190,55 +190,69 @@ def main():
     Setup listener callback for ESC key.
     """
     options = app_options.get_options()
-
     words_gen = word_generator()
 
-    def desktop():
+    def desktop(profile=''):
         # Complete search with desktop settings
         count = options.count if 'count' in options else options.desktop_count
-        print(f'Doing {count} desktop searches')
+        profile_msg = f" using profile '{profile}'" if profile else ""
+        print(f'Doing {count} desktop searches{profile_msg}')
 
-        search(count, words_gen, options.desktop_agent, options)
+        temp_options = options
+        temp_options.profile = profile
+        search(count, words_gen, options.desktop_agent, temp_options)
         print('Desktop Search complete!\n')
 
-    def mobile():
+    def mobile(profile=''):
         # Complete search with mobile settings
         count = options.count if 'count' in options else options.mobile_count
-        print(f'Doing {count} mobile searches')
+        profile_msg = f" using profile '{profile}'" if profile else ""
+        print(f'Doing {count} mobile searches{profile_msg}')
 
-        search(count, words_gen, options.mobile_agent, options)
+        temp_options = options
+        temp_options.profile = profile
+        search(count, words_gen, options.mobile_agent, temp_options)
         print('Mobile Search complete!\n')
 
-    def both():
-        desktop()
-        mobile()
+    def both(profile=''):
+        desktop(profile)
+        mobile(profile)
 
     # Execute main method in a separate thread
     if options.desktop:
-        target = desktop
+        target_func = desktop
     elif options.mobile:
-        target = mobile
+        target_func = mobile
     else:
         # If neither mode is specified, complete both modes
-        target = both
+        target_func = both
 
-    # Start the searching in separate thread
-    search_thread = threading.Thread(target=target, daemon=True)
-    search_thread.start()
+    # If no profiles specified, run once with default (empty) profile
+    profiles = options.profile if options.profile else ['']
 
-    print('Press ESC to quit searching')
+    for profile in profiles:
+        # Start the searching in separate thread
+        search_thread = threading.Thread(target=lambda: target_func(profile), daemon=True)
+        search_thread.start()
 
-    try:
-        # Listen for keyboard events and exit if ESC pressed
-        while search_thread.is_alive():
-            with keyboard.Events() as events:
-                event = events.get(timeout=0.5)  # block for 0.5 seconds
-                # Exit if ESC key pressed
-                if event and event.key == Key.esc:
-                    print('ESC pressed, terminating')
-                    break
-    except KeyboardInterrupt:
-        print('CTRL-C pressed, terminating')
+        print('Press ESC to quit searching')
+
+        try:
+            # Listen for keyboard events and exit if ESC pressed
+            while search_thread.is_alive():
+                with keyboard.Events() as events:
+                    event = events.get(timeout=0.5)  # block for 0.5 seconds
+                    # Exit if ESC key pressed
+                    if event and event.key == Key.esc:
+                        print('ESC pressed, terminating')
+                        return  # Exit the entire function if ESC is pressed
+
+        except KeyboardInterrupt:
+            print('CTRL-C pressed, terminating')
+            return  # Exit the entire function if CTRL-C is pressed
+
+        # Wait for the current profile's searches to complete
+        search_thread.join()
 
     # Open rewards dashboard
     if options.open_rewards and not options.dryrun:

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -195,7 +195,7 @@ def main():
     def desktop(profile=''):
         # Complete search with desktop settings
         count = options.count if 'count' in options else options.desktop_count
-        profile_msg = f" using profile '{profile}'" if profile else ""
+        profile_msg = f" using profile '{profile}'" if profile else ''
         print(f'Doing {count} desktop searches{profile_msg}')
 
         temp_options = options

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -171,7 +171,7 @@ def search(count: int, words_gen: Generator, agent: str, options: Namespace):
             # This is very fast and hopefully reliable
             key_controller.type(search_url + '\n')
 
-        print(f'Search {i+1}: {query}')
+        print(f'Search {i + 1}: {query}')
         # Delay to let page load
         time.sleep(options.search_delay)
 
@@ -227,12 +227,10 @@ def main():
         # If neither mode is specified, complete both modes
         target_func = both
 
-    # If no profiles specified, run once with default (empty) profile
-    profiles = options.profile if options.profile else ['']
-
-    for profile in profiles:
+    # Run for each specified profile (defaults to ['Default'])
+    for profile in options.profile:
         # Start the searching in separate thread
-        search_thread = threading.Thread(target=lambda p=profile: target_func(p), daemon=True)
+        search_thread = threading.Thread(target=target_func, args=(profile,), daemon=True)
         search_thread.start()
 
         print('Press ESC to quit searching')

--- a/bing_rewards/options.py
+++ b/bing_rewards/options.py
@@ -137,9 +137,10 @@ def parse_args() -> Namespace:
     )
     p.add_argument(
         '--profile',
-        help='Sets the chrome profile for launch',
+        help='Sets one or more chrome profiles to run sequentially (space separated)',
         type=str,
-        default='',
+        nargs='*',
+        default=[],
     )
     p.add_argument(
         '--ime',

--- a/bing_rewards/options.py
+++ b/bing_rewards/options.py
@@ -139,8 +139,8 @@ def parse_args() -> Namespace:
         '--profile',
         help='Sets one or more chrome profiles to run sequentially (space separated)',
         type=str,
-        nargs='*',
-        default=[],
+        nargs='+',
+        default=['Default'],
     )
     p.add_argument(
         '--ime',


### PR DESCRIPTION
This PR enhances the `--profile` argument to support running searches across multiple Chrome profiles sequentially.

### Changes:
- Modified `--profile` argument to accept zero or more profile names
- Added profile-specific messaging in console output
- Updated README with the said changes 

### Example usage:
```bash
bing-rewards --profile Default 'Profile 1' 'Profile 2'
```