### PR TITLE
Add support for Wayland session

### DIFF
--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -85,6 +85,8 @@ def browser_cmd(exe: Path, agent: str, profile: str = '') -> list[str]:
     # NO CHECKING IS DONE if the profile exists
     if profile:
         cmd.extend([f'--profile-directory={profile}'])
+    if os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland":
+        cmd.append("--ozone-platform=x11")
     return cmd
 
 


### PR DESCRIPTION
This change ensures compatibility with Wayland by adding a command-line argument to use the X11 platform when the `XDG_SESSION_TYPE` environment variable is set to `wayland`. If it is not set (i.e. in Windows or MacOS, it does not add the `--ozone-platform=x11` flag to the arguments to launch the chromium-based browser. 

This is somewhat a temporary workaround, since it still uses X11 instead of Wayland. I assume if there exist a system that fully uses only Wayland, then this fix would be not applicable to them. But, I have yet to see a system that does that. 

**Tested on:**
* [x] EndeavourOS x86_64
* [x] Windows 11 (if the change will introduce bugs to non-Linux OSes)

Closes #58 