### PR TITLE
feat: enhance browser subprocess termination

### DIFF
--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -159,7 +159,9 @@ def close_browser(chrome: subprocess.Popen | None):
     if os.name == 'posix':
         os.killpg(chrome.pid, signal.SIGTERM)
     else:
-        chrome.kill()
+        subprocess.run(
+            ['taskkill', '/F', '/T', '/PID', str(chrome.pid)], capture_output=True, check=False
+        )
 
 
 def search(count: int, words_gen: Generator, agent: str, options: Namespace):

--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -151,17 +151,40 @@ def open_browser(cmd: list[str]) -> subprocess.Popen:
 
 
 def close_browser(chrome: subprocess.Popen | None):
-    """Close the browser process if it needs to be closed."""
+    """Close the browser process if it exists and is still running.
+
+    Args:
+        chrome: The subprocess.Popen object representing the browser process, or None.
+    """
     if chrome is None:
         return
-    # Close the Chrome window
+
+    if chrome.poll() is not None:  # Check if the process has already terminated
+        print(f'Browser [{chrome.pid}] has already terminated.')
+        return
+
     print(f'Closing browser [{chrome.pid}]')
-    if os.name == 'posix':
-        os.killpg(chrome.pid, signal.SIGTERM)
-    else:
-        subprocess.run(
-            ['taskkill', '/F', '/T', '/PID', str(chrome.pid)], capture_output=True, check=False
-        )
+    try:
+        if os.name == 'posix':
+            os.killpg(chrome.pid, signal.SIGTERM)
+            # Optionally wait for process termination to avoid zombies
+            chrome.wait(timeout=5)  # Wait for up to 5 seconds
+        else:
+            subprocess.run(
+                ['taskkill', '/F', '/T', '/PID', str(chrome.pid)],
+                capture_output=True,
+                check=True,  # raise exception if taskkill fails
+                timeout=5,
+            )
+    except ProcessLookupError:
+        print(f'Browser process [{chrome.pid}] not found (already closed).')
+    except subprocess.CalledProcessError as e:
+        print(f'Error closing browser [{chrome.pid}]: {e}')
+        print(f'Stderr: {e.stderr.decode()}')
+    except subprocess.TimeoutExpired:
+        print(f'Timeout while closing browser [{chrome.pid}].')
+    except Exception as e:
+        print(f'Unexpected error while closing browser [{chrome.pid}]: {e}')
 
 
 def search(count: int, words_gen: Generator, agent: str, options: Namespace):


### PR DESCRIPTION
Enhance the method for closing the browser on Windows by using `taskkill` for more reliable termination.

* `/F` forces the process to terminate
* `/T` terminates the specified process and any child processes started by it

This ensures that the user agent for mobile is applied to every browser instance. Before, it does not apply the mobile user agent to the browser when the browser isn't properly killed. Now, mobile searches work again on Windows.