### PR TITLE
build: ditch dynamic vcs versioning

### DIFF
--- a/bing_rewards/options.py
+++ b/bing_rewards/options.py
@@ -16,7 +16,7 @@ import bing_rewards
 try:
     __version = metadata.version('bing_rewards')
 except metadata.PackageNotFoundError:
-    __version = 'X.X.X+local'
+    __version = 'unknown+local'
 
 # Number of searches to make
 DESKTOP_COUNT = 33

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-  requires      = ["hatchling", "hatch-vcs"]
+  requires      = ["hatchling"]
   build-backend = "hatchling.build"
 
 [project]
   name = "bing-rewards"
-  dynamic = ["version"]
+  version = "3.1.0"
   requires-python = ">=3.10"
   description = "Perform automated Bing Rewards searches"
   license = "MIT"
@@ -37,14 +37,6 @@
 [dependency-groups]
   # dev dependencies picked up automatically by uv
   dev = ["pre-commit-uv~=4.1", "ruff~=0.11"]
-
-[tool.hatch.version]
-  fallback-version = "vX.X.X+unknown"
-  # get the version from git history
-  source                     = "vcs"
-  raw-options.version_scheme = "no-guess-dev"
-  # don't include the +g<commit-hash> in dev versions (to allow test PyPI upload)
-  raw-options.local_scheme = 'no-local-version'
 
 [tool.ruff]
   line-length = 101

--- a/uv.lock
+++ b/uv.lock
@@ -4,6 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "bing-rewards"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pynput" },


### PR DESCRIPTION
Users don't really see or care about this, it was only useful for devs
running local copies. Implied in this change is forgoing any CI that
produces build artifacts on every commit. Cool, but not necessary or
likely to be used on a project of this scale.

Not requiring a git repository (and history) at build time simplifies
other CI, and means a wheel can actually be built from sdist
(important).

The pyproject.toml will be the single-source of truth for the package
version. ~~This means the release-please-manifest is no longer needed.
Release Please action *should* update the pyproject.toml directly (lets
see).~~ Psych! Apparently it is still required. Hopefully will be kept in sync.
