### PR TITLE
build: make releaseplease also bump version in uv.lock

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -8,7 +8,14 @@
       "include-v-in-tag": true,
       "prerelease": false,
       "pull-request-header": "Auto-generated Release",
-      "release-type": "python"
+      "release-type": "python",
+      "extra-files": [
+          {
+            "type": "toml",
+            "path": "uv.lock",
+            "jsonpath": "$.package[?(@.name.value=='bing-rewards')].version"
+          }
+        ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Maybe this is a work around, but other's seem to have run into it as
well. Apparently the json path for a toml file is non-standard and a bit
surprising.
See https://redirect.github.com/googleapis/release-please/issues/2455 for this solution.
