### PR TITLE
feat: skip verifying browser path when --no-window flag is used

### DIFF
--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -193,10 +193,11 @@ def search(count: int, words_gen: Generator, agent: str, options: Namespace):
     Open a chromium browser window with specified `agent` string, complete `count`
     searches from list `words`, finally terminate browser process on completion.
     """
-    cmd = browser_cmd(options.browser_path, agent, options.profile)
     chrome = None
-    if not options.no_window and not options.dryrun:
-        chrome = open_browser(cmd)
+    if not options.no_window:
+        cmd = browser_cmd(options.browser_path, agent, options.profile)
+        if not options.dryrun:
+            chrome = open_browser(cmd)
 
     # Wait for Chrome to load
     time.sleep(options.load_delay)


### PR DESCRIPTION
If a browser is not managed by bing-rewards, there is no need to check
that the path is valid and exists.

This gives more flexibility for users who manually launch a browser, or or have a complex browser setup that can't be launched easily as a subproccess from python (e.g. flatpak)

