### PR TITLE
chore(ci): actually check out the master branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: release-please--branches--master
       - uses: actions/setup-python@v5
         with:
             python-version-file: 'pyproject.toml'


### PR DESCRIPTION
I thought the release PR branch would always be based on new master, but
looks like not.
