### PR TITLE
feat: enable color argparse help on python >= 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: v0.12.0
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
+        args: [ --fix ]
       # Run the formatter.
       - id: ruff-format

--- a/bing_rewards/options.py
+++ b/bing_rewards/options.py
@@ -7,6 +7,7 @@
 import dataclasses
 import json
 import os
+import sys
 from argparse import ArgumentParser, ArgumentTypeError, Namespace, RawDescriptionHelpFormatter
 from importlib import metadata
 from pathlib import Path
@@ -72,7 +73,13 @@ def parse_args() -> Namespace:
         ),
         epilog='* Repository and issues: https://github.com/jack-mil/bing-search',
         formatter_class=RawDescriptionHelpFormatter,
+        prog=Path(sys.argv[0]).name,
     )
+
+    if sys.version_info >= (3, 14):
+        p.suggest_on_error = True  # pyright: ignore[reportUnreachable]
+        p.color = True
+
     p.add_argument('--version', action='version', version=f'%(prog)s v{__version}')
     p.add_argument(
         '-c',


### PR DESCRIPTION
Cool new feature we can take advantage of

Also enabled argument correction suggests on python >= 3.14.
This won't have any effects with the current arguments, but added for
posterity.

fix: absolute path to script in help output on python >= 3.14


This is due to a change to the default `prog` attribute in argparse. It
was meant to prevent '__main__' appearing in the program output when
invoked as a module. But, it breaks all programs that take advantage of
installable entrypoints....

Not sure what they were intending for this. In our case, I override the
name since we only support running from the entrypoint

![Screenshot 2025-06-20 130520](https://github.com/user-attachments/assets/8882e742-3e2a-49f1-98bc-3f2078c34cbc)