### PR TITLE
feat: Enable additional command-line flags in JSON config file

### DIFF
--- a/bing_rewards/options.py
+++ b/bing_rewards/options.py
@@ -268,7 +268,7 @@ def get_options() -> Namespace:
             merged_dict[key] = value
     result = Namespace(**merged_dict)
 
-    # For configs without the new booleans
+    # Ensure all boolean options are set
     result.no_window = not result.window
     result.no_exit = not result.exit
 

--- a/bing_rewards/options.py
+++ b/bing_rewards/options.py
@@ -271,7 +271,5 @@ def get_options() -> Namespace:
     # For configs without the new booleans
     result.no_window = not result.window
     result.no_exit = not result.exit
-    result.open_rewards = result.open_rewards
-    result.bing = result.bing
 
     return result

--- a/bing_rewards/options.py
+++ b/bing_rewards/options.py
@@ -71,6 +71,7 @@ class Config:
     window: bool = True
     exit: bool = True
     ime: bool = False
+    profile: list[str] = dataclasses.field(default_factory=lambda: ['Default'])
 
 
 def parse_args() -> Namespace:
@@ -178,7 +179,6 @@ def parse_args() -> Namespace:
         help='Sets one or more chrome profiles to run sequentially (space separated)',
         type=str,
         nargs='+',
-        default=['Default'],
     )
     args = p.parse_args()
     return args


### PR DESCRIPTION
This PR allows flags such as `--open-rewards`, `--bing`,  and `--no-window` to be set in the configuration file. It also ensures that command-line arguments can properly override these settings at runtime.

Closes #79