### PR TITLE
style: fix ruff lint violations (trailing commas, exception messages, docstrings)

### DIFF
--- a/bing_rewards/__init__.py
+++ b/bing_rewards/__init__.py
@@ -16,6 +16,7 @@ Examples
 Config file: {CONFIG}
 CLI arguments always override the config file.
 Delay timings are in seconds.
+
 """
 
 # This package does not export any programmatic API

--- a/bing_rewards/app.py
+++ b/bing_rewards/app.py
@@ -44,6 +44,7 @@ def word_generator() -> Iterator[str]:
 
     Raises:
         OSError: If there are issues accessing or reading the file.
+
     """
     word_data = resources.files('bing_rewards').joinpath('data', 'keywords.txt')
 
@@ -58,7 +59,8 @@ def word_generator() -> Iterator[str]:
                 size = fh.tell()
 
                 if size == 0:
-                    raise ValueError('Keywords file is empty')
+                    msg = 'Keywords file is empty'
+                    raise ValueError(msg)
 
                 # Start at a random position in the stream
                 fh.seek(random.randint(0, size - 1), io.SEEK_SET)
@@ -97,7 +99,7 @@ def browser_cmd(exe: Path, agent: str, profile: str = '') -> list[str]:
         print(
             f'Command "{exe}" could not be found.\n'
             'Make sure it is available on PATH, '
-            'or use the --exe flag to give an absolute path.'
+            'or use the --exe flag to give an absolute path.',
         )
         sys.exit(1)
 
@@ -121,7 +123,7 @@ def open_browser(cmd: list[str]) -> subprocess.Popen:
         # Only if a new window should be opened
         if os.name == 'posix':
             chrome = subprocess.Popen(
-                cmd, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, start_new_session=True
+                cmd, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, start_new_session=True,
             )
         else:
             chrome = subprocess.Popen(cmd)
@@ -139,6 +141,7 @@ def close_browser(chrome: subprocess.Popen | None):
 
     Args:
         chrome: The subprocess.Popen object representing the browser process, or None.
+
     """
     if chrome is None:
         return
@@ -230,7 +233,8 @@ def search(count: int, words_gen: Iterator[str], agent: str, options: Namespace)
                 delay = random.uniform(min_s, max_s)
             case other:
                 # catastrophic failure
-                raise ValueError(f'Invalid configuration format: "search_delay": {other!r}')
+                msg = f'Invalid configuration format: "search_delay": {other!r}'
+                raise ValueError(msg)
 
         time.sleep(delay)
 

--- a/bing_rewards/options.py
+++ b/bing_rewards/options.py
@@ -180,16 +180,14 @@ def parse_args() -> Namespace:
         type=str,
         nargs='+',
     )
-    args = p.parse_args()
-    return args
+    return p.parse_args()
 
 
 def valid_range(value: str) -> float | tuple[float, float]:
-    """
-    Check that a string is a valid format for the --search-delay flag.
+    """Check that a string is a valid format for the --search-delay flag.
     A valid format looks like:
     --search-delay 10,45
-    --search-delay 20
+    --search-delay 20.
     """
     match value.split(','):
         case [sec] if sec.isdecimal():
@@ -197,10 +195,12 @@ def valid_range(value: str) -> float | tuple[float, float]:
         case [min, max] if min.isdecimal() and max.isdecimal():
             min_s, max_s = float(min), float(max)
             if max_s <= min_s:
-                raise ArgumentTypeError('Max delay should be greater than min.')
+                msg = 'Max delay should be greater than min.'
+                raise ArgumentTypeError(msg)
             return min_s, max_s
         case _:
-            raise ArgumentTypeError('Invalid format. Use numeric value or range.')
+            msg = 'Invalid format. Use numeric value or range.'
+            raise ArgumentTypeError(msg)
 
 
 def valid_file(path: str) -> Path:


### PR DESCRIPTION
Closing this PR — after reflection, this was premature. The automated fixes are mechanically correct but this project isn't ready for external contributions yet. Apologies for the noise. Feel free to run `ruff check . --select COM812,EM101,EM102,RET504,D413,D212,D400,D415 --fix` if you'd like these changes independently.